### PR TITLE
Fix: [#30] wrong input to enable signing commits

### DIFF
--- a/.github/workflows/work-allocator.yml
+++ b/.github/workflows/work-allocator.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           queue_name: "library-update"
           action: "next-job"
-          git_commit_gpg_sign: "true"
+          git_commit_no_gpg_sign: "false"
 
       - name: Update submodule to get new commit ref
         id: update-submodule
@@ -94,7 +94,7 @@ jobs:
           queue_name: "library-update"
           action: "create-job"
           job_payload: "${{ steps.build-payload.outputs.payload }}"
-          git_commit_gpg_sign: "true"
+          git_commit_no_gpg_sign: "false"
 
       - name: Show new git-queue commit
         if: ${{ steps.get-next-job.outputs.job_found == 'false' && steps.update-submodule.outputs.updated == 'true' && steps.create-job.outputs.job_created == 'true' }}

--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           queue_name: "library-update"
           action: "next-job"
-          git_commit_gpg_sign: "true"
+          git_commit_no_gpg_sign: "false"
 
       - name: Parse job payload
         id: parse-payload
@@ -74,7 +74,7 @@ jobs:
           queue_name: "library-update"
           action: "start-job"
           job_payload: ${{ steps.build-start-payload.outputs.payload }}
-          git_commit_gpg_sign: "true"
+          git_commit_no_gpg_sign: "false"
 
         # Begin mutual exclusion job
 
@@ -187,7 +187,7 @@ jobs:
           queue_name: "library-update"
           action: "finish-job"
           job_payload: ${{ steps.build-finish-payload.outputs.payload }}
-          git_commit_gpg_sign: "true"
+          git_commit_no_gpg_sign: "false"
 
       - name: Debug step outputs
         if: ${{ steps.get-next-job.outputs.job_found == 'true' }}


### PR DESCRIPTION
I used the wrong input to enable signing commits:

Wrong:

```
git_commit_gpg_sign: "true"
```

Correct:

```
git_commit_no_gpg_sign: "false"
```

The second one enables signature. The first one allows you to specify the signing key.