### PR TITLE
Rename queue name from `library-update-2` to `library-update-two`

### DIFF
--- a/.github/workflows/work-allocator.yml
+++ b/.github/workflows/work-allocator.yml
@@ -45,7 +45,7 @@ jobs:
         id: get-next-job
         uses: Nautilus-Cyberneering/git-queue@v1-beta
         with:
-          queue_name: "library-update-2"
+          queue_name: "library-update-two"
           action: "next-job"
           git_commit_no_gpg_sign: "false"
 
@@ -93,7 +93,7 @@ jobs:
         if: ${{ steps.get-next-job.outputs.job_found == 'false' && steps.update-submodule.outputs.updated == 'true' }}
         uses: Nautilus-Cyberneering/git-queue@v1-beta
         with:
-          queue_name: "library-update-2"
+          queue_name: "library-update-two"
           action: "create-job"
           job_payload: "${{ steps.build-payload.outputs.payload }}"
           git_commit_no_gpg_sign: "false"

--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -45,7 +45,7 @@ jobs:
         id: get-next-job
         uses: Nautilus-Cyberneering/git-queue@v1-beta
         with:
-          queue_name: "library-update-2"
+          queue_name: "library-update-two"
           action: "next-job"
           git_commit_no_gpg_sign: "false"
 
@@ -73,7 +73,7 @@ jobs:
         if: ${{ steps.get-next-job.outputs.job_found == 'true' }}
         uses: Nautilus-Cyberneering/git-queue@v1-beta
         with:
-          queue_name: "library-update-2"
+          queue_name: "library-update-two"
           action: "start-job"
           job_payload: ${{ steps.build-start-payload.outputs.payload }}
           git_commit_no_gpg_sign: "false"
@@ -186,7 +186,7 @@ jobs:
         if: ${{ steps.start-job.outputs.job_started == 'true' }}
         uses: Nautilus-Cyberneering/git-queue@v1-beta
         with:
-          queue_name: "library-update-2"
+          queue_name: "library-update-two"
           action: "finish-job"
           job_payload: ${{ steps.build-finish-payload.outputs.payload }}
           git_commit_no_gpg_sign: "false"


### PR DESCRIPTION
Git-Queue does allow allow nbumber in the queue name.